### PR TITLE
Update __init__.py

### DIFF
--- a/wdpass/__init__.py
+++ b/wdpass/__init__.py
@@ -10,11 +10,11 @@ import argparse
 import subprocess
 
 try:
-    import py3_sg as py_sg
+    import py_sg
 except ImportError as e:
     print(e)
-    print("You need to install the 'py3_sg' module.")
-    print("More info: https://github.com/7aman/py3_sg")
+    print("You need to install the 'py_sg' module.")
+    print("More info: https://github.com/crypto-universe/py3_sg")
     sys.exit(1)
 
 BLOCK_SIZE = 512


### PR DESCRIPTION
seems the upstream module is already installed as "py_sg" (without 3), so we need to change this for the module to be found.